### PR TITLE
Disable automerge again

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,3 @@
-bot: {automerge: true}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}
 test_on_native_only: true


### PR DESCRIPTION
Was enabled since PR https://github.com/conda-forge/vim-feedstock/pull/1285 was merged automatically by mistake. 

see also: https://github.com/conda-forge/vim-feedstock/pull/1583